### PR TITLE
Fix: Curl command for invoking web actions

### DIFF
--- a/src/pages/guides/using/creating_actions.md
+++ b/src/pages/guides/using/creating_actions.md
@@ -164,11 +164,11 @@ In the URL above, the `default` in the path stands for the `default` package: if
 
 You can invoke the action like this:
 ```
-curl -L https://adobeioruntime.net/api/v1/web/[your namespace]/default/test -x GET
+curl -L https://adobeioruntime.net/api/v1/web/[your namespace]/default/test -X GET
 ```
 or
 ```
-curl https://[your namespace].adobeioruntime.net/api/v1/web/default/test -x GET
+curl https://[your namespace].adobeioruntime.net/api/v1/web/default/test -X GET
 ```
 **Note** the change in the URL here in comparison to what the `wsk` returns. This is due some additional protections Runtime provides to segregate namespaces from each other when invoking web actions. The `wsk` generated link will still work but it will return a 308 redirect to your namespace's subdomain on Runtime. For a further discussion of this please see the [Securing Web Actions](securing_web_actions.md) page.
 


### PR DESCRIPTION
Curl command for invoking web actions:

Original: `curl -L https://adobeioruntime.net/api/v1/web/[your namespace]/default/test -x GET`

**-x** stands for proxy. It should be using **-X** to specify the request method.

Fixed: `curl -L https://adobeioruntime.net/api/v1/web/[your namespace]/default/test -X GET`

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here:  #-->
#28 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by creating and invoking web actions.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
