### PR TITLE
update runtime docs

### DIFF
--- a/src/pages/guides/reference/runtimes.md
+++ b/src/pages/guides/reference/runtimes.md
@@ -1,46 +1,59 @@
 # Runtimes
 
-Adobe I/O Runtime supports Node.js versions 14, 12 and 10. Node v14 is the default image and the one used to create pre-warm containers. We encourage you to always update your actions to the latest version in order to take advantage of pre-warm containers feature.
+Adobe I/O Runtime supports Node.js versions 16, 14, 12 and 10. Node v16 is the default image and the one used to create pre-warm containers. We encourage you to always update your actions to the latest version in order to take advantage of pre-warm containers feature.
 
 The following npm modules are pre-installed (if your action uses any of these modules, you don&rsquo;t have to package them together with action code):
 
-### Node.js v14
+### Node.js v16.15.0
+
+    "express": "4.18.1",
+    "openwhisk": "3.21.6",
+    "body-parser": "1.20.0",
+    "redis": "4.1.0",
+    "node-fetch": "3.2.4",
+    "dnscache": "1.0.2",
+    "prom-client": "13.2.0"
+
+### Node.js v14.16.1
 
     "express": "4.17.1",
-    "openwhisk": "3.21.3",
+    "openwhisk": "3.21.6",
     "body-parser": "1.19.0",
     "cls-hooked": "4.2.2",
     "redis": "3.1.2",
-    "node-fetch": "2.6.7"
-    "dnscache": "1.0.2"
+    "node-fetch": "2.6.7",
+    "dnscache": "1.0.2",
+    "prom-client": "12.0.0"
 
-### Node.js v12
+### Node.js v12.22.1
 
     "express": "4.17.1",
-    "openwhisk": "3.21.2",
+    "openwhisk": "3.21.6",
     "body-parser": "1.19.0",
     "cls-hooked": "4.2.2",
     "redis": "3.0.2",
-    "node-fetch": "2.6.7"
-    "dnscache": "1.0.2"
+    "node-fetch": "2.6.7",
+    "dnscache": "1.0.2",
+    "prom-client": "12.0.0"
 
-### Node.js v10
+### Node.js v10.24.1
 
     "express": "4.16.4",
-    "openwhisk": "3.21.2",
+    "openwhisk": "3.21.6",
     "body-parser": "1.18.3",
     "cls-hooked": "4.2.2",
     "redis": "2.8.0",
     "request": "2.88.0",
-    "request-promise": "4.2.2"
-    "dnscache": "1.0.2"
+    "request-promise": "4.2.2",
+    "dnscache": "1.0.2",
+    "prom-client": "12.0.0"
 
-This is how you can specify explicitly this kind:
+This is how you can specify explicitly a kind:
 ```
-wsk action create actionName fromFile.js --kind nodejs:14 
+wsk action create actionName fromFile.js --kind nodejs:16 
 ```
 or
 ```
-wsk action create actionName fromFile.js --kind nodejs:12 
+wsk action create actionName fromFile.js --kind nodejs:14 
 ```
-We will publish this image on GitHub and Docker Hub.
+We will publish these images on GitHub and Docker Hub.

--- a/src/pages/guides/tools/cli_install.md
+++ b/src/pages/guides/tools/cli_install.md
@@ -14,9 +14,9 @@ After this, you can run help to see all the commands and verify that you are all
 aio -h
 ```
 
-If you want to update to the latest version, run:
+If you want to update to the latest versions of any updated plugins, please reinstall the cli:
 ```
-aio plugins:update
+npm install -g @adobe/aio-cli
 ```
 
 For more information about the `aio` CLI check the [package home page](https://www.npmjs.com/package/@adobe/aio-cli).

--- a/src/pages/guides/using/system_settings.md
+++ b/src/pages/guides/using/system_settings.md
@@ -4,25 +4,26 @@ When creating actions or debugging issues, it is important to know the system se
 
 | Limit | Description | Configurable | Default |  Range  | 
 |---|---| --- | --- | --- |
-| timeout | A container is not allowed to run longer than N milliseconds. Blocking calls (like web actions) can't run longer than 60,000 milliseconds (1 minute). Non-blocking calls can run up to 1,800,000 milliseconds | per action | 60,000 milliseconds | 100ms - 1,800,000ms  |
+| timeout | A container is not allowed to run longer than N milliseconds. Blocking calls (like web actions) can't run longer than 60,000 milliseconds (1 minute). Non-blocking calls can run up to 3,600,000 milliseconds | per action | 60,000 milliseconds | 100ms - 3,600,000ms  |
 | memory | A container is not allowed to allocate more than N MB of memory | per action | 256MB | 128MB - 4096MB |
-| minuteRate (ations)| no more than N actions may be invoked per namespace per minute. If exceded, the error is `429: TOO MANY REQUESTS` | not configurable, per namespace | 600/minute | 600/minute |
+| minuteRate (actions)| no more than N actions may be invoked per namespace per minute. If exceeded, the error is `429: TOO MANY REQUESTS` | not configurable, per namespace | 600/minute | 600/minute |
+| minuteRate (web actions with extra logging)| no more than N web actions may be invoked with the header `X-OW_EXTRA-LOGGING: on` per namespace per minute. If exceeded, the error is `429: TOO MANY REQUESTS` | not configurable, per namespace | 30/minute | 30/minute |
 | logs | A container is not allowed to write more than N MB to stdout | per action | 10MB | 0MB - 10MB |
-| concurrent | No more than N activations may be submitted per namespace either executing or queued for execution. If exceded, the error is `429: TOO MANY REQUESTS` | Not configurable, per namespace | 100 | 100 |
+| concurrent | No more than N activations may be submitted per namespace either executing or queued for execution. If exceeded, the error is `429: TOO MANY REQUESTS` | Not configurable, per namespace | 100 | 100 |
 | action/container concurrency  | The number of action invocations send to the same container in parallel | per action | 200 |1 - 500 |
 | codeSize | The maximum size of the action including dependencies, archived | not configurable, per action | 22MB | 0MB - 22MB |
 | parameters | The maximum size of the parameters that can be attached | not configurable, per action/package/trigger | 1MB | 0 - 1MB |
 | payload | The maximum POST content size plus any carried parameters for an action invocation or trigger firing | not configurable, per action/trigger | 1MB | 0 - 1MB |
 | result | The maximum size of the action result | not configurable, per action | 1MB |  |
-| minuteRate (triggers) | No more than N triggers may be fired per namespace per minute. If exceded, the error is `429: TOO MANY REQUESTS` | not configurable, per namespace | 600/minute | 600/minute |
+| minuteRate (triggers) | No more than N triggers may be fired per namespace per minute. If exceeded, the error is `429: TOO MANY REQUESTS` | not configurable, per namespace | 600/minute | 600/minute |
 | actionsSequenceMaxlength | No more than N actions can be chained in a sequence | not configurable, per namespace | 50 | 50 |
 | list | The maximum number of entities that can be listed | per list request | 30 | 1 - 50 |
 
 ## Sequences and Timeout
 
-Sequences that are invoked in a blocking manner (for example as a weba action have a hard limit for timeout and this limit can't be changed 60 seconds. Essentially, adding up the execution time taken by each action has to be 60 seconds or less.
+Sequences that are invoked in a blocking manner (for example web actions have a hard limit for timeout and this limit can't be changed 60 seconds. Essentially, adding up the execution time taken by each action has to be 60 seconds or less.
 
-Although the system lets you set a higher timeout on the sequnce, this value is ignored and the 60 seconds limit per action is enforced.
+Although the system lets you set a higher timeout on the sequence, this value is ignored and the 60 seconds limit per action is enforced.
 
 If one of your actions needs more than 60 seconds, then the only solution is to invoke a non-blocking action using the OpenWhisk npm module. So, using the same example, you could have `actionA` calling another action in a non-blocking manner. You can see an example of how to do this [here](asynchronous_calls.md).
 
@@ -46,4 +47,4 @@ When you plan on increasing the timeout to more than one minute, you should be a
 
 The activation TTL (Time To Live) is seven days. This is a system setting, not a user setting (it can't be changed by developers).
 
-Thus, if you don't see any activations or not seeing an activation you know that has happened, it could be that they happend more than 7 days ago.
+Thus, if you don't see any activations or not seeing an activation you know that has happened, it could be that they happened more than 7 days ago.


### PR DESCRIPTION
- update async action timeout to 3,600,000 ms
- sync PRs from https://github.com/AdobeDocs/adobeio-runtime

https://github.com/AdobeDocs/adobeio-runtime/pull/90
> - add node 16
> - update packages
> - use SemVer for node versions

https://github.com/AdobeDocs/adobeio-runtime/pull/87
> - aio plugins:update is not recommended anymore because doing so does not update some dependent libraries, leading to unstable CLI setups.
> 
> - The recommendation now is to reinstall the CLI.


https://github.com/AdobeDocs/adobeio-runtime/pull/83
> add minute rate for debug requests
