### PR TITLE
reflect current workflow to add runtime

### DIFF
--- a/src/pages/guides/getting-started/setup.md
+++ b/src/pages/guides/getting-started/setup.md
@@ -28,8 +28,8 @@ If your organization has access to I/O Runtime, then you manage namespaces in th
 
 In the Developer Console:
 * Create a new `Project`
-* Choose one of the workspaces, for example `Production` and then click `Add service` and choose `Runtime` 
-* Go to back to `Workspace overview` page and, at the top of the page, click on the `Download all` button. This will download the configuration file for this project -> workspace
+* Click Enable Runtime in the "Get Started with your new project" box
+* Go to back to `Project overview` page and, at the top of the page, click on the `Download` button. This will download the configuration file for this project -> workspace
 * Open this file in a text editor and search for the `runtime` > `namespaces` entry. This is where you will find the namespace `name` and `auth` values you can use to set the .wskprops file or configue the `aio` CLI (see the next sections). 
 
 ### Configuring the wsk CLI with a .wskprops file


### PR DESCRIPTION
## Description

The concept of workspaces isn't very apparent in the UI.  So I propose removing references to workspaces, and to follow the current UI nomenclature.

## Motivation and Context

I couldn't understand how to download the project settings json file because I was looking for something that doesn't appear in the UI.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
