### PR TITLE
Replace outdated aio -h with aio help

### DIFF
--- a/src/pages/guides/tools/cli_install.md
+++ b/src/pages/guides/tools/cli_install.md
@@ -11,7 +11,7 @@ npm install -g @adobe/aio-cli
 After this, you can run help to see all the commands and verify that you are all set:
 
 ```
-aio -h
+aio help
 ```
 
 If you want to update to the latest versions of any updated plugins, please reinstall the cli:


### PR DESCRIPTION
Replace outdated aio -h with aio help

<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace outdated aio -h with aio help

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/AdobeDocs/adobe-io-runtime/issues/87

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
