### PR TITLE
Update runtimes reference doc

### DIFF
--- a/src/pages/guides/reference/runtimes.md
+++ b/src/pages/guides/reference/runtimes.md
@@ -1,8 +1,18 @@
 # Runtimes
 
-Adobe I/O Runtime supports Node.js versions 16, 14, 12 and 10. Node v16 is the default image and the one used to create pre-warm containers. We encourage you to always update your actions to the latest version in order to take advantage of pre-warm containers feature.
+Adobe I/O Runtime supports Node.js versions 18, 16, and 14. Node v18 is the default image and the one used to create pre-warm containers. We encourage you to always update your actions to the latest version in order to take advantage of the pre-warm containers feature.
 
 The following npm modules are pre-installed (if your action uses any of these modules, you don&rsquo;t have to package them together with action code):
+
+### Node.js v18.14.0
+
+    "express": "4.18.2",
+    "openwhisk": "3.21.7",
+    "body-parser": "1.20.2",
+    "redis": "4.6.5",
+    "node-fetch": "3.3.1",
+    "dnscache": "1.0.2",
+    "prom-client": "14.2.0"
 
 ### Node.js v16.17.0
 
@@ -25,35 +35,13 @@ The following npm modules are pre-installed (if your action uses any of these mo
     "dnscache": "1.0.2",
     "prom-client": "12.0.0"
 
-### Node.js v12.22.12
-
-    "express": "4.17.1",
-    "openwhisk": "3.21.6",
-    "body-parser": "1.19.0",
-    "cls-hooked": "4.2.2",
-    "redis": "3.0.2",
-    "node-fetch": "2.6.7",
-    "dnscache": "1.0.2",
-    "prom-client": "12.0.0"
-
-### Node.js v10.24.1
-
-    "express": "4.16.4",
-    "openwhisk": "3.21.6",
-    "body-parser": "1.18.3",
-    "cls-hooked": "4.2.2",
-    "redis": "2.8.0",
-    "request": "2.88.0",
-    "request-promise": "4.2.2",
-    "dnscache": "1.0.2",
-    "prom-client": "12.0.0"
 
 This is how you can specify explicitly a kind:
 ```
-wsk action create actionName fromFile.js --kind nodejs:16 
+wsk action create actionName fromFile.js --kind nodejs:18 
 ```
 or
 ```
-wsk action create actionName fromFile.js --kind nodejs:14 
+wsk action create actionName fromFile.js --kind nodejs:16 
 ```
 We will publish these images on GitHub and Docker Hub.

--- a/src/pages/guides/reference/runtimes.md
+++ b/src/pages/guides/reference/runtimes.md
@@ -4,7 +4,7 @@ Adobe I/O Runtime supports Node.js versions 18, 16, and 14. Node v18 is the defa
 
 The following npm modules are pre-installed (if your action uses any of these modules, you don&rsquo;t have to package them together with action code):
 
-### Node.js v18.14.0
+### Node.js v18.14.2
 
     "express": "4.18.2",
     "openwhisk": "3.21.7",


### PR DESCRIPTION
Adding node 18 as a supported runtime and removing 10 and 12.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
