### PR TITLE
Fix require-gw-validation annotation name

### DIFF
--- a/src/pages/guides/using/securing_web_actions.md
+++ b/src/pages/guides/using/securing_web_actions.md
@@ -33,12 +33,12 @@ Here is how you can enable IMS Authentication for a web action:
 
 ```
 // create a web action with Require Validation on
-wsk action create my-requir-validation-web-action main.js --web true -a require-validation true
+wsk action create my-requir-validation-web-action main.js --web true -a require-gw-validation true
 ```
 or
 ```
 // update an existing web action to enable Require Validation
-wsk action update my-require-validation-web-action main.js --web true -a require-validation true
+wsk action update my-require-validation-web-action main.js --web true -a require-gw-validation true
 ```
 
 To interact with the action, it's necessary to set up a security configuration in your Swagger API route for that action. Detailed instructions on how to do this can be found in the documentation titled "[Securing the API Endpoints](https://developer.adobe.com/runtime/docs/guides/using/creating_rest_apis/#securing-the-api-endpoints).".  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the annotation name that has to be used in order to enable Oauth2 validation. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
