### PR TITLE
docs: add Node.js 24 and 26 to supported runtimes reference

### DIFF
--- a/src/pages/guides/reference/runtimes.md
+++ b/src/pages/guides/reference/runtimes.md
@@ -4,6 +4,24 @@ Adobe I/O Runtime supports the three latest Node.js versions (see the [Node.js r
 
 The following npm modules are pre-installed (if your action uses any of these modules, you don&rsquo;t have to package them together with action code):
 
+### Node.js v26.1.0
+
+    "express": "4.22.2",
+    "openwhisk": "3.21.9",
+    "body-parser": "1.20.5",
+    "redis": "4.7.1",
+    "dnscache": "1.0.2",
+    "prom-client": "14.2.0"
+
+### Node.js v24.0.1
+
+    "express": "4.21.1",
+    "openwhisk": "3.21.8",
+    "body-parser": "1.20.3",
+    "redis": "4.6.13",
+    "dnscache": "1.0.2",
+    "prom-client": "14.2.0"
+
 ### Node.js V22.6.0
 
     "express": "4.18.2",
@@ -65,8 +83,10 @@ or
 aio rt:action:create actionName fromFile.js --kind nodejs:18 
 ```
 These images are on Docker Hub:
-1. [Node 22](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v22/tags)
-2. [Node 20](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v20/tags)
-3. [Node 18](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v18/tags)
-4. [Node 16](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v16/tags)
-5. [Node 14](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v14/tags)
+1. [Node 26](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v26/tags)
+2. [Node 24](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v24/tags)
+3. [Node 22](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v22/tags)
+4. [Node 20](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v20/tags)
+5. [Node 18](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v18/tags)
+6. [Node 16](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v16/tags)
+7. [Node 14](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v14/tags)


### PR DESCRIPTION
## Description

Adds two Node.js versions to the public supported-runtimes reference at https://developer.adobe.com/runtime/docs/guides/reference/runtimes/:

- **Node.js v26.1.0** — the kind that just shipped to prod (image `bladerunner/adobe-action-nodejs-v26:3.0.45`).
- **Node.js v24.0.1** — missed in last year's rollout; backfilled here so the page reflects current prod state.

## Related Issue

Internal tracking: ACNA-4589 (Node 26 docs / release notes), ACNA-4585 (Node 26 epic)

## Motivation and Context

`@adobe/aio-lib-runtime` [7.4.0](https://github.com/adobe/aio-lib-runtime/releases/tag/7.4.0) was published advertising `nodejs:26` to all CLI/SDK users. The doc page is what `aio-lib-runtime/src/utils.js` points readers at via its `SupportedRuntimes` comment, so it needs to match — otherwise users land on a page that lists kinds the CLI now supports as missing.

Node 24 was a doc gap from the previous rollout; folded in here to bring the page up to current prod state.

Reference:

- Kind PR: https://git.corp.adobe.com/bladerunner/openwhisk-runtime-nodejs/pull/176
- Version-bump PR (release/3.0.45): https://git.corp.adobe.com/bladerunner/openwhisk-runtime-nodejs/pull/177
- Lib release: https://github.com/adobe/aio-lib-runtime/releases/tag/7.4.0

## How Has This Been Tested?

Docs-only PR. Verified the source `runtimes.md` renders correctly via the existing build pipeline; module-version values cross-checked against the merged `package.json` files in `bladerunner/openwhisk-runtime-nodejs` for each kind.

Prod parity for `nodejs:26` was verified end-to-end before this PR:

- `https://adobeioruntime.net` lists `nodejs:26` with image `bladerunner/adobe-action-nodejs-v26:3.0.45`
- `aio app deploy` succeeds with `kind: nodejs:26`; `aio rt action list` shows the action registered with the new kind alongside existing kinds

## Screenshots (if appropriate):

N/A — text-only addition to an existing reference page.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.